### PR TITLE
Downgrade smoothscroll dep: ^0.4.0 -> ^0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "react-ga": "^2.5.7",
     "react-waypoint": "^9.0.2",
-    "smoothscroll": "^0.4.0"
+    "smoothscroll": "^0.3.0"
   },
   "files": [
     "/dist/"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5652,6 +5652,11 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+smoothscroll@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/smoothscroll/-/smoothscroll-0.3.0.tgz#6e79644d8449c51f29226a833a7440dae9162ed0"
+  integrity sha1-bnlkTYRJxR8pImqDOnRA2ukWLtA=
+
 smoothscroll@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/smoothscroll/-/smoothscroll-0.4.0.tgz#40e507b46461408ba1b787d0081e1e883c4124a5"


### PR DESCRIPTION
### Change Reason
`twreporter-react` and `@twreporter/react-components` installed `^0.3.0` version.
In order to reduce the bundle size, downgrade `smoothscroll` from `v0.4.0` to `v0.3.0`. 