### PR TITLE
Revert "Resolve modules from the `node_modules` of this repo firstly"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,9 +17,6 @@ const config = {
     port: 8080,
   },
   devtool: 'eval-source-map',
-  resolve: {
-    modules: [path.resolve(__dirname, 'node_modules'), 'node_modules'],
-  },
   module: {
     rules: [
       {


### PR DESCRIPTION
The purpose of the original commit is to prevent webpack-dev-server to take the node_modules in its dependencies when using yarn link. But it will cause webpack taking wrong package if there are different version of the same packge be installed.

This reverts commit ae19ad876a031d765fc5ab25b904c0af1e0ac999.